### PR TITLE
feat: add content preview API configuration to Nuxt settings

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -59,4 +59,9 @@ export default defineNuxtConfig({
         mode: "css",
         cssLayer: "base",
     },
+    content: {
+        preview: {
+            api: 'https://api.nuxt.studio'
+        }
+    }
 });


### PR DESCRIPTION
This pull request introduces a new `content` configuration block in the `nuxt.config.ts` file to enable a preview feature with a specified API endpoint.

* **New Content Preview Configuration**:
  - Added a `content.preview` section to the Nuxt configuration, specifying the API endpoint as `https://api.nuxt.studio`. (`[nuxt.config.tsR62-R66](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R62-R66)`)