### PR TITLE
locale: add initial swedish translations

### DIFF
--- a/components/educationEntry.vue
+++ b/components/educationEntry.vue
@@ -12,7 +12,7 @@
                 <Tag v-show="isPresent" class="bg-blue-100! text-blue-950!">Present</Tag>
                 <Tag v-for="tag in education.tags" :key="tag">{{
                     tag
-                }}</Tag>
+                    }}</Tag>
             </div>
         </div>
         <div class="md:pl-4 space-y-2 flex-1">
@@ -38,6 +38,8 @@
 <script setup lang="ts">
 import type { EducationCollectionItem } from "@nuxt/content";
 
+const { t, locale } = useI18n();
+
 const props = defineProps<{
     education: EducationCollectionItem;
 }>();
@@ -53,7 +55,7 @@ const isPresent = computed(() => {
 });
 
 const startDateString = computed(() => {
-    return new Date(education.value.startDate).toLocaleDateString("en-US", {
+    return new Date(education.value.startDate).toLocaleDateString(locale.value, {
         month: "short",
         year: "numeric",
     });
@@ -61,10 +63,10 @@ const startDateString = computed(() => {
 
 const endDateString = computed(() => {
     const date = new Date(education.value.endDate);
-    const dateString = date.toLocaleDateString("en-US", {
+    const dateString = date.toLocaleDateString(locale.value, {
         month: "short",
         year: "numeric",
     });
-    return date > new Date() ? `Expected ${dateString}` : dateString;
+    return date > new Date() ? `${t("dictionary.expected")} ${dateString}` : dateString;
 });
 </script>

--- a/components/experienceEntry.vue
+++ b/components/experienceEntry.vue
@@ -38,6 +38,8 @@
 <script setup lang="ts">
 import type { ExperiencesCollectionItem } from "@nuxt/content";
 
+const { t, locale } = useI18n();
+
 const props = defineProps<{
     experience: ExperiencesCollectionItem;
 }>();
@@ -53,7 +55,7 @@ const isPresent = computed(() => {
 });
 
 const startDateString = computed(() => {
-    return new Date(experience.value.startDate).toLocaleDateString("en-US", {
+    return new Date(experience.value.startDate).toLocaleDateString(locale.value, {
         month: "short",
         year: "numeric",
     });
@@ -61,8 +63,8 @@ const startDateString = computed(() => {
 
 const endDateString = computed(() => {
     return new Date(experience.value.endDate).getDate() === new Date("2100-01-01").getDate()
-        ? "Present"
-        : new Date(experience.value.endDate).toLocaleDateString("en-US", {
+        ? t("dictionary.present")
+        : new Date(experience.value.endDate).toLocaleDateString(locale.value, {
             month: "short",
             year: "numeric",
         });

--- a/components/footer.vue
+++ b/components/footer.vue
@@ -4,11 +4,10 @@
             class="flex flex-col md:mx-8 lg:mx-12 xl:mx-20 flex-1 bg-white border-x border-gray-300 border-dashed hover:border-solid divide-y divide-gray-300 divide-dashed">
             <FooterSection class="flex justify-between items-center">
                 <div>
-                    <h6 class="font-semibold">Get in touch</h6>
-                    <p class="font-medium text-gray-500">Send me an email.</p>
+                    <h6 class="font-semibold">{{ $t("footer.contact.title") }}</h6>
+                    <p class="font-medium text-gray-500">{{ $t("footer.contact.description") }}</p>
                 </div>
                 <NuxtLink :to="`mailto:${$t('info.emailAddress')}`" external class="flex btn-light items-center gap-2">
-
                     {{ $t("info.emailAddress") }}
                     <Icon name="solar:plain-2-broken" class="h-4 w-4 bg-gray-600" />
                 </NuxtLink>
@@ -19,16 +18,22 @@
             </FooterSection>
             <FooterSection
                 class="flex flex-col md:flex-row md:items-end md:justify-between text-gray-600 font-mono text-sm text-center pb-12">
-                <p class="md:text-left">
-                    Iteration {{ iteration }} Patch {{ minor }} <br />All rights
-                    reserved © {{ year }} {{ $t("info.url") }}
-                </p>
-                <p class="md:text-right">
-                    Made with <span class="text-green-400">Nuxt</span> and
-                    <span class="text-sky-400">Tailwind CSS</span>
-                    <br />
-                    Designed and engineered by Anson Ng
-                </p>
+                <div class="md:text-left">
+                    <p class="capitalize">
+                        {{ $t("footer.version.majorLabel") }} {{ iteration }} {{ $t("footer.version.patchLabel") }} {{
+                            minor
+                        }}
+                    </p>
+                    <p>{{ $t("footer.copyright.description") }} {{ year }} {{ $t("info.url") }}</p>
+                </div>
+                <div class="md:text-right">
+                    <p>
+                        {{ $t("footer.copyright.madeWith") }} <span class="text-green-600">Nuxt</span> {{
+                            $t("dictionary.and") }}
+                        <span class="text-sky-400">Tailwind CSS</span>
+                    </p>
+                    <p>{{ $t("footer.copyright.credit") }}</p>
+                </div>
             </FooterSection>
         </div>
     </footer>

--- a/components/navBar.vue
+++ b/components/navBar.vue
@@ -9,28 +9,28 @@
                 <NuxtImg src="/favicon.svg" alt="Logo" class="h-10 w-10 items-center hover:invert transition" />
             </NuxtLink>
             <div class="flex flex-col items-center">
-                <NuxtLinkLocale to="/">Home</NuxtLinkLocale>
+                <NuxtLinkLocale to="/" class="capitalize"> {{ $t("nav.home") }}</NuxtLinkLocale>
                 <transition name="slide-up">
                     <div class="h-0.5 w-4 bg-blue-600 rounded"
                         v-show="currentRouteName?.toString().startsWith('index')" />
                 </transition>
             </div>
             <div class="flex flex-col items-center">
-                <NuxtLinkLocale to="/about">About</NuxtLinkLocale>
+                <NuxtLinkLocale to="/about" class="capitalize"> {{ $t("nav.about") }}</NuxtLinkLocale>
                 <transition name="slide-up">
                     <div class="h-0.5 w-4 bg-blue-600 rounded"
                         v-show="currentRouteName?.toString().startsWith('about')" />
                 </transition>
             </div>
             <button class="flex flex-col items-center" @click="toggleContact" :aria-expanded="isExpanded.contact">
-                <span>Contact</span>
+                <span class="capitalize">{{ $t("nav.contact") }}</span>
                 <transition name="slide-up">
                     <div class="h-0.5 w-4 bg-blue-600 rounded" v-show="isExpanded.contact" />
                 </transition>
             </button>
             <div class="flex flex-col items-center">
-                <NuxtLink to="/cv/resume.pdf" external class="flex items-center gap-1">
-                    CV
+                <NuxtLink to="/cv/resume.pdf" external class="flex items-center gap-1 uppercase">
+                    {{ $t("nav.cv") }}
                     <Icon name="solar:import-broken" class="h-4 w-4 bg-gray-600" />
                 </NuxtLink>
             </div>

--- a/content/education/sv/2023_bachelor_cuhk.json
+++ b/content/education/sv/2023_bachelor_cuhk.json
@@ -1,0 +1,18 @@
+{
+    "locale": "sv",
+    "startDate": "2023-08-01",
+    "endDate": "2027-07-01",
+    "location": "Hongkong",
+    "school": "The Chinese University of Hong Kong",
+    "degree": "Kandidatexamen i datavetenskap",
+    "gpa": 3.88,
+    "description": "Kandidatexamen i datavetenskap",
+    "highlights": [
+        "Mottagare av dekanens lista | 2023 - 2024 | GPA: 3.88",
+        "Erhöll 7 stipendier"
+    ],
+    "pathToLogo": "cuhk.svg",
+    "tags": [
+        "Kandidat"
+    ]
+}

--- a/content/education/sv/2026_exchange_kth.json
+++ b/content/education/sv/2026_exchange_kth.json
@@ -1,0 +1,16 @@
+{
+    "locale": "sv",
+    "startDate": "2026-01-01",
+    "endDate": "2026-06-01",
+    "location": "Stockholm, Sverige",
+    "school": "Kungliga Tekniska Högskolan",
+    "degree": "Utbytesprogram",
+    "description": "Kandidatexamen i datavetenskap",
+    "highlights": [
+        "Deltog i utbytesprogrammet vid KTH Kungliga Tekniska högskolan"
+    ],
+    "pathToLogo": "kth.svg",
+    "tags": [
+        "Utbyte"
+    ]
+}

--- a/content/experiences/en/2024_ra_cuhk.json
+++ b/content/experiences/en/2024_ra_cuhk.json
@@ -14,6 +14,6 @@
     "pathToLogo": "cuhk.svg",
     "tags": [
         "Python",
-        "BATS Codes"
+        "Network"
     ]
 }

--- a/content/experiences/sv/2023_instructor_lamwoo.json
+++ b/content/experiences/sv/2023_instructor_lamwoo.json
@@ -1,0 +1,19 @@
+{
+    "locale": "sv",
+    "startDate": "2023-07-01",
+    "endDate": "2023-12-01",
+    "location": "Hongkong",
+    "company": "SKH Lam Woo Memorial Secondary School",
+    "title": "Instruktör",
+    "description": "Instruktör",
+    "highlights": [
+        "Undervisade 15 elever i årskurs 3 till 5 i två fördjupningskurser: Avancerad programmering (Python) och Datastrukturer och algoritmer (Kotlin), vilket förbättrade deras kodningsförmåga.",
+        "Utvecklade lektionsmaterial och kodningsövningar, vilket fördjupade elevernas behärskning av objektorienterad programmering och algoritmiska koncept, samtidigt som de använde Git för att lämna in sina kursarbeten.",
+        "Mentorerade elever för Hongkongs olympiad i informatik genom riktad coachning, vilket resulterade i att 3 elever avancerade till finalstadiet."
+    ],
+    "pathToLogo": "lamwoo.png",
+    "tags": [
+        "Python",
+        "Kotlin"
+    ]
+}

--- a/content/experiences/sv/2023_programmer_lamwoo.json
+++ b/content/experiences/sv/2023_programmer_lamwoo.json
@@ -1,0 +1,18 @@
+{
+    "locale": "sv",
+    "startDate": "2023-07-01",
+    "endDate": "2023-12-01",
+    "location": "Hongkong",
+    "company": "SKH Lam Woo Memorial Secondary School",
+    "title": "Programmerare",
+    "description": "Programmerare",
+    "highlights": [
+        "Omvandlade ett pappersbaserat disciplinärt system till en papperslös lösning med Google Suite, vilket löste problem med att sammanfoga register från olika avdelningar och minskade manuell datainmatning.",
+        "Utvecklade arbetsflöden med JavaScript-baserade Google Apps Script, integrerade med befintliga FoxPro-baserade administrativa system, för att hämta och uppdatera elevdata samt generera rapporter."
+    ],
+    "pathToLogo": "lamwoo.png",
+    "tags": [
+        "JavaScript",
+        "Apps Script"
+    ]
+}

--- a/content/experiences/sv/2024_ra_cuhk.json
+++ b/content/experiences/sv/2024_ra_cuhk.json
@@ -1,0 +1,19 @@
+{
+    "locale": "sv",
+    "startDate": "2024-04-01",
+    "endDate": "2100-01-01",
+    "location": "Hongkong",
+    "company": "Kinesiska universitetet i Hongkong",
+    "title": "Forskningsassistent",
+    "description": "Forskningsassistent",
+    "highlights": [
+        "Optimerar batchstorlekar och buffertstorlekar för mellanliggande noder för att förbättra överföringseffektiviteten under schemat för batched sparse codes (BATS).",
+        "Ledde ett team för att utveckla en Python-simulator för att replikera trådlös kommunikation i multi-hop-nätverk med BATS-koder som överföringsmetod.",
+        "Använde simulatorn för att mäta maximala paketmottagningshastigheter över tid vid destinationsnoden i linjenätverksscenarier med paketförlust."
+    ],
+    "pathToLogo": "cuhk.svg",
+    "tags": [
+        "Python",
+        "Nätverk"
+    ]
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -66,6 +66,8 @@
         }
     },
     "dictionary": {
-        "and": "and"
+        "and": "and",
+        "expected": "expected",
+        "present": "present"
     }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,10 +1,4 @@
 {
-    "index": {
-        "greeting": "Hej! I'm @:info.firstName{'.'}",
-        "intro": "is a dedicated BSc Computer Science student at the Chinese University of Hong Kong, with a passion for delivering exceptional user experience (UX) design. Driven by a strong interest in software engineering and UX design, I am committed to creating innovative and user-centric solutions. Currently, I am open to new opportunities to apply my skills and contribute to impactful projects.",
-        "portraitAlt": "A recent random photo taken at gym.",
-        "portraitCaption": "This is Me!"
-    },
     "info": {
         "role": "Computer Science Student / UI Designer",
         "firstName": "Anson",
@@ -18,8 +12,60 @@
         "instagramUrl": "https://www.instagram.com/anson_ryea/",
         "linkedinUrl": "https://www.linkedin.com/in/an5on/"
     },
+    "nav": {
+        "home": "home",
+        "about": "about",
+        "contact": "contact",
+        "cv": "cv"
+    },
     "locales": {
         "en": "english",
         "sv": "swedish"
+    },
+    "index": {
+        "greeting": {
+            "title": "Hello, I'm @:info.firstName{'.'}",
+            "description": "Nothing more than an ordinary human.",
+            "intro": {
+                "label": "intro",
+                "paragraph": "is a dedicated BSc Computer Science student at the Chinese University of Hong Kong, with a passion for delivering exceptional user experience (UX) design. Driven by a strong interest in software engineering and UX design, I am committed to creating innovative and user-centric solutions. Currently, I am open to new opportunities to apply my skills and contribute to impactful projects."
+            }
+        },
+        "portrait": {
+            "label": "portrait",
+            "alt": "A recent random photo taken at gym.",
+            "caption": "This is Me!"
+        },
+        "polaroids": "polaroids",
+        "currentStatus": {
+            "label": "current-status",
+            "title": "Current Status",
+            "description": "What am I doing currently?"
+        }
+    },
+    "about": {
+        "title": "About me",
+        "description": "I am a computer science student with a fervent passion for software engineering and UI/UX design.",
+        "biography": "biography",
+        "education": "education",
+        "experiences": "experiences"
+    },
+    "footer": {
+        "contact": {
+            "title": "Get in touch",
+            "description": "Send me an email."
+        },
+        "version": {
+            "majorLabel": "iteration",
+            "patchLabel": "patch"
+        },
+        "copyright": {
+            "description": "All rights reserved ©",
+            "madeWith": "Made with",
+            "credit": "Designed and engineered by @:info.name"
+        }
+    },
+    "dictionary": {
+        "and": "and"
     }
 }

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -66,6 +66,8 @@
         }
     },
     "dictionary": {
-        "and": "och"
+        "and": "och",
+        "expected": "förväntad",
+        "present": "nutid"
     }
 }

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -1,6 +1,71 @@
 {
+    "info": {
+        "role": "Datavetenskapsstudent / UI-designer",
+        "firstName": "Anson",
+        "middleName": "Cheuk-nam",
+        "lastName": "Ng",
+        "name": "@:info.firstName @:info.lastName",
+        "fullName": "@:info.firstName @:info.middleName @:info.lastName",
+        "emailAddress": "hej{'@'}an5on.com",
+        "url": "an5on.com",
+        "githubUrl": "https://github.com/anson-ryea",
+        "instagramUrl": "https://www.instagram.com/anson_ryea/",
+        "linkedinUrl": "https://www.linkedin.com/in/an5on/"
+    },
+    "nav": {
+        "home": "hem",
+        "about": "om",
+        "contact": "kontakt",
+        "cv": "cv"
+    },
     "locales": {
         "en": "engelska",
         "sv": "svenska"
+    },
+    "index": {
+        "greeting": {
+            "title": "Hej, jag är @:info.firstName{'.'}",
+            "description": "Inget mer än en vanlig människa.",
+            "intro": {
+                "label": "introduktion",
+                "paragraph": "är en engagerad student i kandidatexamen i datavetenskap vid Chinese University of Hong Kong, med en passion för att leverera enastående användarupplevelse (UX)-design. Drivs av ett starkt intresse för mjukvaruutveckling och UX-design, är jag engagerad i att skapa innovativa och användarcentrerade lösningar. För närvarande är jag öppen för nya möjligheter att tillämpa mina färdigheter och bidra till betydelsefulla projekt."
+            }
+        },
+        "portrait": {
+            "label": "porträtt",
+            "alt": "Ett nyligen taget slumpmässigt foto på gymmet.",
+            "caption": "Detta är jag!"
+        },
+        "polaroids": "polaroider",
+        "currentStatus": {
+            "label": "nuvarande-status",
+            "title": "Nuvarande status",
+            "description": "Vad gör jag för närvarande?"
+        }
+    },
+    "about": {
+        "title": "Om mig",
+        "description": "Jag är en datavetenskapsstudent med en brinnande passion för mjukvaruutveckling och UI/UX-design.",
+        "biography": "biografi",
+        "education": "utbildning",
+        "experiences": "erfarenheter"
+    },
+    "footer": {
+        "contact": {
+            "title": "Kontakta mig",
+            "description": "Skicka mig ett e-postmeddelande."
+        },
+        "version": {
+            "majorLabel": "iteration",
+            "patchLabel": "uppdatering"
+        },
+        "copyright": {
+            "description": "Alla rättigheter förbehållna ©",
+            "madeWith": "Skapad med",
+            "credit": "Designad och utvecklad av @:info.name"
+        }
+    },
+    "dictionary": {
+        "and": "och"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "portfolio",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "portfolio",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "hasInstallScript": true,
             "dependencies": {
                 "@nuxt/content": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "portfolio",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "private": true,
     "type": "module",
     "scripts": {

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -138,4 +138,8 @@ const { data: experiences } = await useAsyncData("experiences", () => {
 const { data: education } = await useAsyncData("education", () => {
     return queryCollection("education").where("locale", "=", locale.value).order("endDate", "DESC").all();
 });
+
+watch(locale, async () => {
+    refreshNuxtData(["experiences", "education"]);
+});
 </script>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -5,13 +5,12 @@
             <div class="h-16 w-full bg-linear-to-t from-blue-100/20" />
             <IndexSection class="bg-linear-to-b from-blue-100/20 space-y-8">
                 <div>
-                    <h3 class="text-gray-400">About me</h3>
+                    <h3 class="text-gray-400">{{ $t("about.title") }}</h3>
                     <h1 class="font-serif">
-                        I am a computer science student with a fervent passion
-                        for software engineering and UI/UX design.
+                        {{ $t("about.description") }}
                     </h1>
                 </div>
-                <ConsoleLikePane paneName="biography.md">
+                <ConsoleLikePane :paneName="`${$t('about.biography')}.md`">
                     <div class="md:columns-2 space-y-8 font-serif">
                         <p>
                             Born and raised in Hong Kong, I am the first to
@@ -105,9 +104,9 @@
                 </ConsoleLikePane>
             </IndexSection>
             <IndexSection>
-                <ConsoleLikePane paneName="education.db">
+                <ConsoleLikePane :paneName="`${$t('about.education')}.db`">
                     <div class="space-y-4 md:flex md:justify-between md:space-x-16">
-                        <h2>Education</h2>
+                        <h2 class="capitalize">{{ $t("about.education") }}</h2>
                         <div class="divide-y divide-gray-300 flex-1">
                             <EducationEntry v-for="ed in education" :education="ed" class="py-4 first:pt-0!" />
                         </div>
@@ -115,9 +114,9 @@
                 </ConsoleLikePane>
             </IndexSection>
             <IndexSection>
-                <ConsoleLikePane paneName="experiences.db">
+                <ConsoleLikePane :paneName="`${$t('about.experiences')}.db`">
                     <div class="space-y-4 md:flex md:justify-between md:space-x-16">
-                        <h2>Experiences</h2>
+                        <h2 class="capitalize">{{ $t("about.experiences") }}</h2>
                         <div class="divide-y divide-gray-300 flex-1 max-md:divide-dashed">
                             <ExperienceEntry v-for="experience in experiences" :experience="experience"
                                 class="py-4 first:pt-0!" />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,13 +13,13 @@
                 <div class="h-16 w-full bg-linear-to-t from-blue-100/20" />
                 <IndexSection class="bg-linear-to-b from-blue-100/20">
                     <div class="flex flex-col space-y-12 lg:flex-row lg:space-x-12 lg:space-y-0">
-                        <ConsoleLikePane paneName="intro.md" class="flex-1">
+                        <ConsoleLikePane :paneName="`${$t('index.greeting.intro.label')}.md`" class="flex-1">
                             <template #default>
                                 <div class="space-y-4 sm:space-y-8 lg:space-y-12">
                                     <div class="space-y-2">
-                                        <h1>{{ $t("index.greeting") }}</h1>
+                                        <h1>{{ $t("index.greeting.title") }}</h1>
                                         <h3 class="text-gray-400 font-serif">
-                                            Nothing more than an ordinary human.
+                                            {{ $t("index.greeting.description") }}
                                         </h3>
                                     </div>
                                     <SeeThroughBox>
@@ -27,7 +27,7 @@
                                             <span class="text-black">{{
                                                 $t("info.fullName")
                                             }}</span>
-                                            {{ $t("index.intro") }}
+                                            {{ $t("index.greeting.intro.paragraph") }}
                                         </p>
                                     </SeeThroughBox>
                                 </div>
@@ -41,16 +41,17 @@
                                 </ClientOnly>
                             </template>
                         </ConsoleLikePane>
-                        <ConsoleLikePane paneName="portrait.png" class="">
-                            <Polaroid :src="'index/portrait.jpg'" :caption="$t('index.portraitCaption')"
-                                :alt="$t('index.portraitAlt')" class="aspect-3/4 max-w-88" img-class="object-top!" />
+                        <ConsoleLikePane :paneName="`${$t('index.portrait.label')}.png`" class="">
+                            <Polaroid :src="'index/portrait.jpg'" :caption="$t('index.portrait.caption')"
+                                :alt="$t('index.portrait.alt')" class="aspect-3/4 max-w-88" img-class="object-top!" />
                         </ConsoleLikePane>
                     </div>
                 </IndexSection>
                 <IndexSection>
-                    <ConsoleLikePane paneName="polaroids">
-                        <div
-                            class="flex space-x-4 max-w-full md:max-xl:grid md:grid-cols-2 md:gap-8 justify-between justify-items-center overflow-x-auto md:overflow-visible">
+                    <ConsoleLikePane :paneName="$t('index.polaroids')">
+                        <div class="flex space-x-4 max-w-full md:max-xl:grid md:grid-cols-2 md:gap-8 justify-between
+                            justify-items-center
+                            overflow-x-auto md:overflow-visible">
                             <Polaroid :src="'/index/polaroids/salford.png'" caption="Salford, UK"
                                 class="aspect-3/4 w-48 md:w-60 xl:max-w-88 xl:h-fit xl:w-full" />
                             <!-- <Polaroid
@@ -72,16 +73,16 @@
                     </ConsoleLikePane>
                 </IndexSection>
                 <IndexSection>
-                    <ConsoleLikePane paneName="current-status.md">
+                    <ConsoleLikePane :paneName="`${$t('index.currentStatus.label')}.md`">
                         <div class="space-y-4">
                             <div>
-                                <h2>Current Status</h2>
+                                <h2>{{ $t("index.currentStatus.title") }}</h2>
                                 <h3 class="text-gray-400 font-serif">
-                                    What am I doing currently?
+                                    {{ $t("index.currentStatus.description") }}
                                 </h3>
                             </div>
                             <div class="divide-y divide-gray-300 flex-1 max-md:divide-dashed">
-                                <EducationEntry v-for="ed in presentEducation" :education="ed"
+                                <EducationEntry v-for="education in presentEducation" :education="education"
                                     class="py-4 first:pt-0!" />
                                 <ExperienceEntry v-for="experience in presentExperiences" :experience="experience"
                                     class="py-4 first:pt-0!" />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,7 @@
                                         <p>
                                             <span class="text-black">{{
                                                 $t("info.fullName")
-                                            }}</span>
+                                                }}</span>
                                             {{ $t("index.greeting.intro.paragraph") }}
                                         </p>
                                     </SeeThroughBox>
@@ -141,4 +141,8 @@ const { data: presentEducation } = await useAsyncData(
             .all();
     },
 );
+
+watch(locale, async () => {
+    refreshNuxtData(["presentExperiences", "presentEducation"]);
+});
 </script>


### PR DESCRIPTION
This pull request introduces Swedish (i18n) support across the portfolio application, ensuring content is dynamically translated based on the user's selected locale. Key changes include integrating i18n into components, adding Swedish translations, and updating the content structure to support multiple languages.

### Internationalization Integration

* `components/educationEntry.vue` and `components/experienceEntry.vue`: Added i18n support for `startDate` and `endDate` formatting using the `locale` value, and replaced static text like "Expected" and "Present" with translatable keys (`t("dictionary.expected")`, `t("dictionary.present")`) [[1]](diffhunk://#diff-803632ef3384e51f40bd524108fd23505671e91808ed6c835f63cb3f2d0f2f4aR41-R42) [[2]](diffhunk://#diff-803632ef3384e51f40bd524108fd23505671e91808ed6c835f63cb3f2d0f2f4aL56-R70) [[3]](diffhunk://#diff-be5562232baa2e0d7ad9d40810f7e450ba6b1f6f509c2b6cca1a6f6209c673adR41-R42) [[4]](diffhunk://#diff-be5562232baa2e0d7ad9d40810f7e450ba6b1f6f509c2b6cca1a6f6209c673adL56-R67).
* `components/footer.vue` and `components/navBar.vue`: Replaced static text with i18n keys for footer and navigation labels (e.g., `footer.contact.title`, `nav.home`) to enable localization [[1]](diffhunk://#diff-45a0dde9637f50ff1e2e69f413a3828336c2668bff9b22ee047d1ce21c36170cL7-L11) [[2]](diffhunk://#diff-45a0dde9637f50ff1e2e69f413a3828336c2668bff9b22ee047d1ce21c36170cL22-R36) [[3]](diffhunk://#diff-3075e18a947e51d5adc3c82da2ef0a2eec382da33b29ff7b438117bb85ae151bL12-R33).
* [`pages/about.vue`](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3L8-R13): Updated headings and pane names to use i18n keys, ensuring dynamic translations for the "About Me" section [[1]](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3L8-R13) [[2]](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3L108-R119).

### New Translations

* `i18n/locales/en.json` and `i18n/locales/sv.json`: Added Swedish translations alongside English for navigation, footer, and dictionary terms, as well as descriptions for the "About Me" and "Current Status" sections [[1]](diffhunk://#diff-4c5e948ebdf8601f1013d7979d2e623707d40bb142d1889d5666473f15f6fd5dL2-L7) [[2]](diffhunk://#diff-4c5e948ebdf8601f1013d7979d2e623707d40bb142d1889d5666473f15f6fd5dR15-R71) [[3]](diffhunk://#diff-adb1fa7f2dbe5aa0233a234b89415b77eacf44fa58d6cbae1b163c0983cc4232R2-R71).

### Content Updates for Localization

* Added Swedish content for education and experience entries, including details about institutions, roles, and highlights [[1]](diffhunk://#diff-03920c43578ba6f4893f484e223052fbaa12178c1d5b57cfb21a129997c9c9fbR1-R18) [[2]](diffhunk://#diff-e51eb66cac9268750105a85ae559d8a0d6b3d6ccf8df5b4fb5242cd81ca924d7R1-R16) [[3]](diffhunk://#diff-ec37e6b8b52b3729f9d14c499c0f4daaa6ecf262ceb75e70692c2ccdceb91ef7R1-R19) [[4]](diffhunk://#diff-d8c7e0e1717ecb5ccdd8a9272499dae14885a4fdd375f56ce019878c2fac3edfR1-R18) [[5]](diffhunk://#diff-f8042d55701d8555d0446afba64b79df85f6233f5f5b9db7f50c0296aea31465R1-R19).
* Updated tags in existing experience entries to align with localization needs (e.g., replacing "BATS Codes" with "Network").

### Miscellaneous

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented version number to `2.1.2` to reflect the addition of i18n support.
* [`pages/about.vue`](diffhunk://#diff-b10942e88a1a75cc0044cdafd5a2b6dc81068901722be8708978731fefee6eb3R141-R144): Added a watcher on `locale` to refresh education and experience data dynamically when the locale changes.