### PR TITLE
feat: add GPA widget in education entry

### DIFF
--- a/app/components/educationEntry.vue
+++ b/app/components/educationEntry.vue
@@ -27,13 +27,27 @@
     </div>
     <div class="md:pl-4 space-y-4 flex-1">
       <div class="space-y-2">
-        <div class="rounded-full bg-gray-100 p-2 w-fit">
-          <NuxtImg
-            :src="education.pathToLogo"
-            :alt="education.school + $t('dictionary.logoAlt')"
-            class="h-12 w-12"
-            width="48"
-          />
+        <div class="flex items-center gap-2">
+          <div class="rounded-full bg-gray-100 p-2 w-fit">
+            <NuxtImg
+              :src="education.pathToLogo"
+              :alt="education.school + $t('dictionary.logoAlt')"
+              class="h-12 w-12"
+              width="48"
+            />
+          </div>
+          <div
+            v-if="education.gpa"
+            class="rounded-lg bg-gray-100 p-2 overflow-hidden h-16 w-24 space-y-1"
+          >
+            <div class="flex justify-between items-start">
+              <div class="h-1 w-1 bg-blue-600 rounded-full" />
+              <span class="text-center text-2xs font-mono text-blue-600 uppercase">{{ $t('about.education.gpa') }}</span>
+            </div>
+            <span class="block text-center font-serif text-2xl">
+              {{ education.gpa }}<span class="text-xs text-gray-600">/{{ education.maxGpa.toFixed(1) }}</span>
+            </span>
+          </div>
         </div>
         <div>
           <h6 class="font-medium">
@@ -41,7 +55,10 @@
           </h6>
           <p>{{ education.school }}</p>
         </div>
-        <p class="text-gray-600 font-serif">
+        <p
+          v-if="education.description"
+          class="text-gray-600 font-serif"
+        >
           {{ education.description }}
         </p>
         <ul class="text-gray-600 list-disc list-inside font-serif">
@@ -110,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-import type { EducationCollectionItem } from '@nuxt/content'
+import type { EducationCollectionItem } from '@nuxt/content';
 
 const { t, locale } = useI18n()
 

--- a/app/components/educationEntry.vue
+++ b/app/components/educationEntry.vue
@@ -127,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-import type { EducationCollectionItem } from '@nuxt/content';
+import type { EducationCollectionItem } from '@nuxt/content'
 
 const { t, locale } = useI18n()
 

--- a/content.config.ts
+++ b/content.config.ts
@@ -1,4 +1,4 @@
-import { defineContentConfig, defineCollection, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig, z } from '@nuxt/content'
 
 export default defineContentConfig({
     collections: {
@@ -29,6 +29,7 @@ export default defineContentConfig({
                 school: z.string(),
                 degree: z.string(),
                 gpa: z.number(),
+                maxGpa: z.number(),
                 description: z.string(),
                 highlights: z.array(z.string()),
                 tags: z.array(z.string()),

--- a/content/education/en/2023_bachelor_cuhk.json
+++ b/content/education/en/2023_bachelor_cuhk.json
@@ -5,10 +5,11 @@
   "location": "Hong Kong",
   "school": "The Chinese University of Hong Kong",
   "degree": "Bachelor of Science in Computer Science",
-  "gpa": 3.88,
-  "description": "Bachelor of Science in Computer Science",
+  "gpa": 3.83,
+  "maxGpa": 4.0,
   "highlights": [
-    "Dean's List Recipient | 2023 - 2024 | GPA: 3.88"
+    "Dean's List Recipient | 2023 - 2024",
+    "Dean's List Recipient | 2024 - 2025"
   ],
   "pathToLogo": "/content/education/cuhk.svg",
   "tags": [

--- a/content/education/sv/2023_bachelor_cuhk.json
+++ b/content/education/sv/2023_bachelor_cuhk.json
@@ -5,10 +5,11 @@
   "location": "Hongkong",
   "school": "The Chinese University of Hong Kong",
   "degree": "Kandidatexamen i datavetenskap",
-  "gpa": 3.88,
-  "description": "Kandidatexamen i datavetenskap",
+  "gpa": 3.83,
+  "maxGpa": 4.0,
   "highlights": [
-    "Mottagare av dekanens lista | 2023 - 2024 | GPA: 3.88"
+    "Mottagare av Dean's List | 2023 - 2024",
+    "Mottagare av Dean's List | 2024 - 2025"
   ],
   "pathToLogo": "/content/education/cuhk.svg",
   "tags": [

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -55,7 +55,8 @@
         "biography": "biography",
         "education": {
             "label": "education",
-            "scholarships": "scholarships"
+            "scholarships": "scholarships",
+            "gpa": "gpa"
         },
         "experiences": "experiences"
     },

--- a/i18n/locales/sv.json
+++ b/i18n/locales/sv.json
@@ -55,7 +55,8 @@
         "biography": "biografi",
         "education": {
             "label": "utbildning",
-            "scholarships": "stipendier"
+            "scholarships": "stipendier",
+            "gpa": "gpa"
         },
         "experiences": "erfarenheter"
     },


### PR DESCRIPTION
This pull request updates the education section to display GPA information more clearly and consistently, improves the data structure for education entries, and enhances internationalization support for GPA labels. The most important changes are grouped below:

**Education Entry Display Improvements:**

* Added a new GPA display component to `educationEntry.vue`, showing both the GPA and its maximum value in a styled box if GPA data is present.
* Updated the education entry to only show the description if it exists, improving conditional rendering.

**Data Structure and Content Updates:**

* Added a `maxGpa` field to the education collection schema in `content.config.ts` and updated education JSON files to include `maxGpa` and revised GPA values and highlights. [[1]](diffhunk://#diff-292443c3bab83756c4445b17b0579b7dafd30862019530587b5ade74fb21c84dR32) [[2]](diffhunk://#diff-f7fb5f0c92ad2791dd59b70297c2380a17635b9fc16489db04571dc326230b7aL8-R12) [[3]](diffhunk://#diff-03920c43578ba6f4893f484e223052fbaa12178c1d5b57cfb21a129997c9c9fbL8-R12)

**Internationalization (i18n) Enhancements:**

* Added the `gpa` label to both English and Swedish translation files for proper localization of the GPA display. [[1]](diffhunk://#diff-4c5e948ebdf8601f1013d7979d2e623707d40bb142d1889d5666473f15f6fd5dL58-R59) [[2]](diffhunk://#diff-adb1fa7f2dbe5aa0233a234b89415b77eacf44fa58d6cbae1b163c0983cc4232L58-R59)